### PR TITLE
Add function for generating asset manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ after building the bundle and rebuilds if they change.
 
 `buildCSS(inputs)` - Build one or more CSS bundles from CSS or SASS entry points.
 
+`generateManifest(options)` - Generate a JSON asset manifest suitable for use
+with the [h-assets](https://pypi.org/project/h-assets/) package used by Python
+apps to serve static assets.
+
 ### Running tests
 
 `runTests(config)` - Build a JavaScript bundle of tests from a set of input files
@@ -94,7 +98,7 @@ and run them in Karma.
 
 The test bundle is created by first finding all test files that match the
 `testsPattern` argument and generating an entry point,
-`build/scripts/test-inputs.js`, which imports all of the test files. The 
+`build/scripts/test-inputs.js`, which imports all of the test files. The
 bundle is then built by passing the config specified by `rollupConfig` to
 Rollup. Once the bundle has been generated, Karma is started using the config
 file specified by `karmaConfig`, which should load the test bundle.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export { buildJS, watchJS } from './lib/rollup.js';
 export { buildCSS } from './lib/sass.js';
+export { generateManifest } from './lib/manifest.js';
 export { runTests } from './lib/tests.js';
 export { run } from './lib/run.js';

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -1,0 +1,55 @@
+import { createHash } from 'crypto';
+import { readFile, writeFile } from 'fs/promises';
+import * as path from 'path';
+
+import glob from 'glob';
+
+/**
+ * Generate a manifest that maps asset paths to cache-busted URLs.
+ *
+ * The generated manifest file is suitable for use with the h-assets Python
+ * package (https://pypi.org/project/h-assets/) used by backend Hypothesis
+ * projects for serving static assets. The manifest looks like:
+ *
+ * ```
+ * {
+ *   "scripts/app.bundle.js": "scripts/app.bundle.js?abc123",
+ *   "styles/app.css": "styles/app.css?def456",
+ *   ...
+ * }
+ * ```
+ *
+ * Returns the data that was written to the manifest.
+ *
+ * @param {object} options
+ *   @param {string} [options.pattern] - Glob pattern that specifies which assets to include
+ *   @param {string} [options.manifestPath] - File path to write the manifest to
+ * @return {Promise<Record<string, string>>}
+ */
+export async function generateManifest({
+  pattern = 'build/**/*.{css,js,map}',
+  manifestPath = 'build/manifest.json',
+} = {}) {
+  const manifestDir = path.dirname(manifestPath);
+  const files = glob.sync(pattern);
+
+  /** @type {Record<string, string>} */
+  const manifest = {};
+
+  await Promise.all(
+    files.map(async file => {
+      const fileContent = await readFile(file);
+      const hash = await createHash('sha1');
+      hash.update(fileContent);
+
+      const hashSuffix = hash.digest('hex').slice(0, 6);
+      const relativePath = path.relative(manifestDir, file);
+      manifest[relativePath] = `${relativePath}?${hashSuffix}`;
+    })
+  );
+
+  const manifestData = Buffer.from(JSON.stringify(manifest, null, 2), 'utf-8');
+  await writeFile(manifestPath, manifestData);
+
+  return manifest;
+}


### PR DESCRIPTION
Add a `generateManifest` function that generates a JSON file mapping
relative asset URLs to cache-busted paths. This was extracted from the
`scripts/gulp/manifest.js` file present in several downstream projects
(client, lms, h) but revised to use Node's simpler promise-based file
access APIs instead of Node streams.