### PR TITLE
Do not process with tailwind if no configuration provided

### DIFF
--- a/lib/sass.js
+++ b/lib/sass.js
@@ -8,9 +8,6 @@ import sass from 'sass';
 /**
  * @typedef {import('tailwindcss').Config} TailwindConfig
  */
-const defaultTailwindConfig = /** @type {TailwindConfig} */ ({
-  theme: {},
-});
 
 /**
  * Build CSS bundles from SASS or CSS inputs.
@@ -24,15 +21,12 @@ const defaultTailwindConfig = /** @type {TailwindConfig} */ ({
  *   Optional tailwind config object
  * @return {Promise<void>} Promise for completion of the build.
  */
-export async function buildCSS(
-  inputs,
-  { tailwindConfig = defaultTailwindConfig } = {}
-) {
+export async function buildCSS(inputs, { tailwindConfig } = {}) {
   const outDir = 'build/styles';
   const minify = process.env.NODE_ENV === 'production';
   await mkdir(outDir, { recursive: true });
 
-  /** @type {import('postcss').PluginCreator<import('tailwindcss').Config>} */
+  /** @type {import('postcss').PluginCreator<TailwindConfig>} */
   let tailwindcss;
   try {
     tailwindcss = (await import('tailwindcss')).default;
@@ -53,7 +47,7 @@ export async function buildCSS(
       });
 
       const optionalPlugins = [];
-      if (tailwindcss) {
+      if (tailwindcss && tailwindConfig) {
         optionalPlugins.push(tailwindcss(tailwindConfig));
       }
 


### PR DESCRIPTION
Depends on #128

Update `sass` task to only apply the `tailwindcss` postcss plugin if
both of these things are true:

* The `tailwindcss` package is available for import, AND
* A `tailwindConfig` option is provided

This eliminates the need for projects that use this project's `sass` gulp task to have to pass a dummy `tailwindConfig` when the source does not need to be processed with tailwind.