### PR TITLE
Change `tests` option from `--watch` to `--live` to avoid node conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Rollup. Once the bundle has been generated, Karma is started using the config
 file specified by `karmaConfig`, which should load the test bundle.
 
 This command supports filtering which tests are run
-by using the `--grep <file pattern>` CLI argument. If the `--watch` CLI flag is
+by using the `--grep <file pattern>` CLI argument. If the `--live` CLI flag is
 set, the test runner watches for changes and rebuild and re-runs the tests if
 the input files change.
 

--- a/lib/tests.js
+++ b/lib/tests.js
@@ -34,11 +34,11 @@ export async function runTests({
       '--grep <pattern>',
       'Run only tests where filename matches a regex pattern'
     )
-    .option('--watch', 'Continuously run tests (default: false)', false)
+    .option('--live', 'Continuously run tests (default: false)', false)
     .parse(process.argv);
 
-  const { grep, watch } = program.opts();
-  const singleRun = !watch;
+  const { grep, live } = program.opts();
+  const singleRun = !live;
 
   // Generate an entry file for the test bundle. This imports all the test
   // modules, filtered by the pattern specified by the `--grep` CLI option.


### PR DESCRIPTION
Node 18.11 [introduced a core `--watch`](https://github.com/nodejs/node/pull/44366) flag. This creates a conflict with using a `--watch` option in the `tests` task module. For now, change the name of the task's option to `--live` to avoid this conflict.

Updated usage:

`gulp test --live`


## Testing this change

* In the `main` branch of the `client`, with a local node version of >=18.11, try running `gulp test --watch`. It should fail.
* Check out this branch of `frontend-build`. Run `yalc publish`
* In the `client` directory, run `yalc add @hypothesis/frontend-build`
* In the `client`, run `gulp test --live`. It should work: tests should run and then run again on input/source file changes