### PR TITLE
Migrate away from legacy sass API

### DIFF
--- a/lib/sass.js
+++ b/lib/sass.js
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from 'fs/promises';
-import { basename, dirname, extname } from 'path';
+import { basename, dirname, extname, relative } from 'path';
 
 import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';
@@ -37,13 +37,12 @@ export async function buildCSS(inputs, { tailwindConfig } = {}) {
   await Promise.all(
     inputs.map(async input => {
       const output = `${outDir}/${basename(input, extname(input))}.css`;
-      const sourcemapPath = output + '.map';
+      const sourceMapPath = `${output}.map`;
 
-      const sassResult = sass.renderSync({
-        file: input,
-        includePaths: [dirname(input), 'node_modules'],
-        outputStyle: minify ? 'compressed' : 'expanded',
-        sourceMap: sourcemapPath,
+      const sassResult = sass.compile(input, {
+        loadPaths: [dirname(input), 'node_modules'],
+        style: minify ? 'compressed' : 'expanded',
+        sourceMap: true,
       });
 
       const optionalPlugins = [];
@@ -58,12 +57,22 @@ export async function buildCSS(inputs, { tailwindConfig } = {}) {
         to: output,
         map: {
           inline: false,
-          prev: sassResult.map?.toString(),
+          prev: JSON.stringify(sassResult.sourceMap),
         },
       });
+      const sourceMappingURL = relative(dirname(output), sourceMapPath);
 
-      await writeFile(output, postcssResult.css);
-      await writeFile(sourcemapPath, postcssResult.map.toString());
+      await writeFile(
+        output,
+        // We have to manually add the sourceMappingURL comment, because
+        // `sass.compile(...)` does not do it by itself.
+        // https://sass-lang.com/documentation/js-api/interfaces/Options#sourceMap
+        // It's important to know that URI-encoding the sourceMappingURL might
+        // be needed if we start using characters outside the [0-9a-zA-Z-_.] set
+        // in file names
+        `${postcssResult.css}\n/*# sourceMappingURL=${sourceMappingURL} */`
+      );
+      await writeFile(sourceMapPath, postcssResult.map.toString());
     })
   );
 }


### PR DESCRIPTION
Closes #329

This PR migrates `buildCSS` to the new sass JS API.