### PR TITLE
Fix importing from sass package, since it no longer has a default export

### DIFF
--- a/lib/sass.js
+++ b/lib/sass.js
@@ -3,7 +3,7 @@ import { basename, dirname, extname, relative } from 'path';
 
 import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';
-import sass from 'sass';
+import * as sass from 'sass';
 
 /**
  * @typedef {import('tailwindcss').Config} TailwindConfig


### PR DESCRIPTION
The `sass` package in version 1.63 has changed its exports and there doesn't seem to be a default export anymore.