### PR TITLE
Fix ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows

### DIFF
--- a/lib/rollup.js
+++ b/lib/rollup.js
@@ -1,4 +1,5 @@
 import { resolve } from 'path';
+import url from 'url';
 
 import log from 'fancy-log';
 import * as rollup from 'rollup';
@@ -10,7 +11,7 @@ function logRollupWarning(warning) {
 
 /** @param {string} path */
 async function readConfig(path) {
-  const { default: config } = await import(resolve(path));
+  const { default: config } = await import(url.pathToFileURL(resolve(path)));
   return Array.isArray(config) ? config : [config];
 }
 


### PR DESCRIPTION
When attempting to build hypothesis/client on a Windows 10 machine, I got the following error:

```
~\Code\hypothesis-client> yarn run build
yarn run v1.22.19
$ cross-env NODE_ENV=production gulp build
[21:49:17] Using gulpfile ~\Code\hypothesis-client\gulpfile.mjs
[21:49:17] Starting 'build'...
[21:49:17] Starting 'build-js'...
[21:49:17] Starting 'build-css'...
[21:49:17] Starting 'build-fonts'...
[21:49:17] Starting 'build-annotator-tailwind-css'...
[21:49:17] Starting 'build-sidebar-tailwind-css'...
[21:49:17] Starting 'build-standalone-css'...
[21:49:17] 'build-js' errored after 15 ms
[21:49:17] Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at new NodeError (node:internal/errors:400:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1055:11)
    at defaultResolve (node:internal/modules/esm/resolve:1135:3)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:842:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ESMLoader.import (node:internal/modules/esm/loader:525:22)
    at importModuleDynamically (node:internal/modules/esm/translators:110:35)
    at importModuleDynamicallyCallback (node:internal/process/esm_loader:35:14)
    at readConfig (file:///C:/Users/pirx/Code/hypothesis-client/node_modules/@hypothesis/frontend-build/lib/rollup.js:13:44)
[21:49:17] 'build' errored after 21 ms
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I have confirmed that the proposed change fixes the problem in my environment. I have not checked whether this change breaks the build on other platforms.