### PR TITLE
Make sure argument to `import()` is a string

### DIFF
--- a/lib/rollup.js
+++ b/lib/rollup.js
@@ -11,7 +11,8 @@ function logRollupWarning(warning) {
 
 /** @param {string} path */
 async function readConfig(path) {
-  const { default: config } = await import(url.pathToFileURL(resolve(path)));
+  const fileURL = url.pathToFileURL(resolve(path)).toString();
+  const { default: config } = await import(fileURL);
   return Array.isArray(config) ? config : [config];
 }
 


### PR DESCRIPTION
This fixes a typecheck error in lib/rollup.js.