### PR TITLE
Allow consumers to override default Rollup warning handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ the input files change.
 
 ### Utilities
 
+`log.{info, warn, error}(message...)` - Log a message with a timestamp. This
+is a re-export of [fancy-log](https://www.npmjs.com/package/fancy-log)'s API.
+
 `run(command, args)` - Run a CLI command and forward the output to the terminal.
 
 ## Additional documentation

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+export { default as log } from 'fancy-log';
+
 export { buildJS, watchJS } from './lib/rollup.js';
 export { buildCSS } from './lib/sass.js';
 export { generateManifest } from './lib/manifest.js';

--- a/lib/rollup.js
+++ b/lib/rollup.js
@@ -27,8 +27,8 @@ export async function buildJS(rollupConfig) {
   await Promise.all(
     configs.map(async config => {
       const bundle = await rollup.rollup({
-        ...config,
         onwarn: logRollupWarning,
+        ...config,
       });
       await bundle.write(config.output);
     }),
@@ -47,8 +47,8 @@ export async function watchJS(rollupConfig) {
 
   const watcher = rollup.watch(
     configs.map(config => ({
-      ...config,
       onwarn: logRollupWarning,
+      ...config,
     })),
   );
 

--- a/lib/rollup.js
+++ b/lib/rollup.js
@@ -6,7 +6,7 @@ import * as rollup from 'rollup';
 
 /** @param {import('rollup').RollupLog} warning */
 function logRollupWarning(warning) {
-  log.info(`Rollup warning: ${warning} (${warning.url})`);
+  log.warn(`Rollup warning: ${warning} (${warning.url})`);
 }
 
 /** @param {string} path */


### PR DESCRIPTION
When running tests in h there is currently a warning about use of `eval` by the `syn` test dependency which I want to [suppress](https://github.com/hypothesis/h/pull/9117). This PR contains a set of changes to allow users of this package to provide their own Rollup warning handlers instead of using the default one from this package.

- Use `log.warn` instead of `log.info` in the default Rollup warning handler
- Make `onwarn` handler in Rollup config take precedence over the default handler provided by this package
- Re-export [fancy-log](https://www.npmjs.com/package/fancy-log) so consumers can log messages in the same format as this package