### PR TITLE
Remove eslint types package, as latest eslint ships type definitions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,8 @@
-import globals from 'globals';
 import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
+import globals from 'globals';
 
-export default [
+export default defineConfig([
   js.configs.recommended,
   {
     languageOptions: {
@@ -12,4 +13,4 @@ export default [
       sourceType: 'module',
     },
   },
-];
+]);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lib/*.js"
   ],
   "devDependencies": {
-    "@types/eslint__js": "^8.42.3",
     "@types/fancy-log": "^2.0.0",
     "@types/glob": "^8.0.0",
     "@types/karma": "^6.3.1",
@@ -20,7 +19,7 @@
     "@types/sass": "^1.16.1",
     "@types/tailwindcss": "^3.0.2",
     "autoprefixer": "^10.3.7",
-    "eslint": "^9.12.0",
+    "eslint": "^9.23.0",
     "karma": "^6.3.4",
     "postcss": "^8.3.9",
     "prettier": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,7 +154,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hypothesis/frontend-build@workspace:."
   dependencies:
-    "@types/eslint__js": ^8.42.3
     "@types/fancy-log": ^2.0.0
     "@types/glob": ^8.0.0
     "@types/karma": ^6.3.1
@@ -163,7 +162,7 @@ __metadata:
     "@types/tailwindcss": ^3.0.2
     autoprefixer: ^10.3.7
     commander: ^13.0.0
-    eslint: ^9.12.0
+    eslint: ^9.23.0
     fancy-log: ^2.0.0
     glob: ^11.0.0
     karma: ^6.3.4
@@ -594,26 +593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:*":
-  version: 9.6.1
-  resolution: "@types/eslint@npm:9.6.1"
-  dependencies:
-    "@types/estree": "*"
-    "@types/json-schema": "*"
-  checksum: c286e79707ab604b577cf8ce51d9bbb9780e3d6a68b38a83febe13fa05b8012c92de17c28532fac2b03d3c460123f5055d603a579685325246ca1c86828223e0
-  languageName: node
-  linkType: hard
-
-"@types/eslint__js@npm:^8.42.3":
-  version: 8.42.3
-  resolution: "@types/eslint__js@npm:8.42.3"
-  dependencies:
-    "@types/eslint": "*"
-  checksum: e31f19de642d35a664695d0cab873ce6de19b8a3506755835b91f8a49a8c41099dcace449df49f1a486de6fa6565d21ceb1fa33be6004fc7adef9226e5d256a1
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:*, @types/estree@npm:1.0.6, @types/estree@npm:^1.0.6":
+"@types/estree@npm:1.0.6, @types/estree@npm:^1.0.6":
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 8825d6e729e16445d9a1dd2fb1db2edc5ed400799064cd4d028150701031af012ba30d6d03fe9df40f4d7a437d0de6d2b256020152b7b09bde9f2e420afdffd9
@@ -637,7 +617,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.15":
+"@types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
@@ -1493,7 +1473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.12.0":
+"eslint@npm:^9.23.0":
   version: 9.23.0
   resolution: "eslint@npm:9.23.0"
   dependencies:


### PR DESCRIPTION
Remove `@types/eslint__js`, which is no longer needed with more modern eslint versions.

Also use `defineConfig` from `eslint/config`  in `eslint.config.js`, as it allows for a type-safe definition of eslint config.