### PR TITLE
Set allowExcessArguments in commander used in runTests

### DIFF
--- a/lib/tests.js
+++ b/lib/tests.js
@@ -32,6 +32,7 @@ export async function runTests({
 }) {
   // Parse command-line options for test execution.
   program
+    .allowExcessArguments()
     .option(
       '--grep <pattern>',
       'Run only tests where filename matches a regex pattern',


### PR DESCRIPTION
Fix an error introduced after [updating to commander 13](https://github.com/hypothesis/frontend-build/pull/653), which now errors if there's an excess in arguments.

Since we use it only to allow the `--grep` and `--live` options, it is safe to allow excess arguments as documented here https://github.com/tj/commander.js/blob/master/CHANGELOG.md#migration-tips