### PR TITLE
Make autoprefixer, postcss and sass optional peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,16 @@
     "vitest": "^3.1.1"
   },
   "peerDependenciesMeta": {
+    "autoprefixer": {
+      "optional": true
+    },
     "karma": {
+      "optional": true
+    },
+    "postcss": {
+      "optional": true
+    },
+    "sass": {
       "optional": true
     },
     "tailwindcss": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,7 +357,13 @@ __metadata:
     tailwindcss: ^3.0.11
     vitest: ^3.1.1
   peerDependenciesMeta:
+    autoprefixer:
+      optional: true
     karma:
+      optional: true
+    postcss:
+      optional: true
+    sass:
       optional: true
     tailwindcss:
       optional: true


### PR DESCRIPTION
Autoprefixer, postcss and sass are only used by the `sass` module. Making them optional so that downstream projects can install this library without unnecessary dependencies if they are only going to use some of the other modules.

A case for this is the browser-extension, which will only use the tests module but not the sass one https://github.com/hypothesis/browser-extension/pull/1725#discussion_r2068250323