### PR TITLE
Add individual exports for all utility modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ gulp.task('test', () => runTests({
 // Project-specific tasks...
 ```
 
+Functions can be imported from the main export, or from individual ones if you
+don't want to install all optional peer dependencies:
+
+```js
+import { buildJS, watchJS } from '@hypothesis/frontend-build/rollup';
+import { buildCSS } from '@hypothesis/frontend-build/sass';
+import { runTests } from '@hypothesis/frontend-build/tests';
+
+```
+
 ## API reference
 
 This section provides an overview of the functions in this package. See the

--- a/package.json
+++ b/package.json
@@ -3,7 +3,26 @@
   "version": "3.2.2",
   "description": "Hypothesis frontend build scripts",
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": {
+      "import": "./index.js"
+    },
+    "./manifest": {
+      "import": "./lib/manifest.js"
+    },
+    "./rollup": {
+      "import": "./lib/rollup.js"
+    },
+    "./run": {
+      "import": "./lib/run.js"
+    },
+    "./sass": {
+      "import": "./lib/sass.js"
+    },
+    "./tests": {
+      "import": "./lib/tests.js"
+    }
+  },
   "repository": "https://github.com/hypothesis/frontend-build",
   "author": "Hypothesis developers",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
Following with https://github.com/hypothesis/frontend-build/pull/736, define individual exports so that we can truly avoid installing the optional peer dependencies, without all of them being imported by the package's barrel file