### PR TITLE
Remove support for autoprefixer and Tailwind v3

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -10,8 +10,6 @@ import postcss from 'postcss';
 
 /**
  * @typedef Options
- * @prop {boolean} [autoprefixer] - Enable the Autoprefixer PostCSS plugin
- * @prop {object} [tailwindConfig] - Enable Tailwind v3 with the given configuration.
  * @prop {boolean} [tailwind] - Enable Tailwind v4 or later.
  */
 
@@ -25,25 +23,14 @@ import postcss from 'postcss';
  * @param {Options} options
  * @return {Promise<void>} Promise for completion of the build.
  */
-export async function buildCSS(
-  inputs,
-  { autoprefixer = true, tailwind = false, tailwindConfig } = {},
-) {
+export async function buildCSS(inputs, { tailwind = false } = {}) {
   const outDir = 'build/styles';
   const minify = process.env.NODE_ENV === 'production';
   await mkdir(outDir, { recursive: true });
 
-  if (tailwind && tailwindConfig) {
-    throw new Error(
-      'Only one of `tailwind` (for Tailwind v4+) or `tailwindConfig` (for Tailwind v3) should be set',
-    );
-  }
-
   /** @type {PluginCreator<any>} */
   let tailwindcss;
-  if (tailwindConfig) {
-    tailwindcss = /** @type {any} */ (await import('tailwindcss')).default;
-  } else if (tailwind) {
+  if (tailwind) {
     tailwindcss = (await import('@tailwindcss/postcss')).default;
   }
 
@@ -70,11 +57,7 @@ export async function buildCSS(
 
       const plugins = [];
       if (tailwindcss) {
-        plugins.push(tailwindcss(tailwindConfig));
-      }
-      if (autoprefixer) {
-        const autoprefixerPlugin = (await import('autoprefixer')).default;
-        plugins.push(autoprefixerPlugin());
+        plugins.push(tailwindcss());
       }
 
       const cssProcessor = postcss(plugins);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/glob": "^9.0.0",
     "@types/node": "^24.0.2",
     "@types/sass": "^1.16.1",
-    "autoprefixer": "^10.3.7",
     "eslint": "^9.23.0",
     "postcss": "^8.3.9",
     "prettier": "^3.0.0",
@@ -56,7 +55,6 @@
   },
   "peerDependencies": {
     "@tailwindcss/postcss": "^4.1.13",
-    "autoprefixer": "^10.3.7",
     "postcss": "^8.3.9",
     "rollup": "^4.0.2",
     "sass": "^1.43.2",
@@ -65,9 +63,6 @@
   },
   "peerDependenciesMeta": {
     "@tailwindcss/postcss": {
-      "optional": true
-    },
-    "autoprefixer": {
       "optional": true
     },
     "postcss": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,7 +355,6 @@ __metadata:
     "@types/glob": ^9.0.0
     "@types/node": ^24.0.2
     "@types/sass": ^1.16.1
-    autoprefixer: ^10.3.7
     commander: ^14.0.0
     eslint: ^9.23.0
     fancy-log: ^2.0.0
@@ -369,7 +368,6 @@ __metadata:
     vitest: ^3.1.1
   peerDependencies:
     "@tailwindcss/postcss": ^4.1.13
-    autoprefixer: ^10.3.7
     postcss: ^8.3.9
     rollup: ^4.0.2
     sass: ^1.43.2
@@ -377,8 +375,6 @@ __metadata:
     vitest: ^3.1.1
   peerDependenciesMeta:
     "@tailwindcss/postcss":
-      optional: true
-    autoprefixer:
       optional: true
     postcss:
       optional: true
@@ -1267,24 +1263,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.3.7":
-  version: 10.4.21
-  resolution: "autoprefixer@npm:10.4.21"
-  dependencies:
-    browserslist: ^4.24.4
-    caniuse-lite: ^1.0.30001702
-    fraction.js: ^4.3.7
-    normalize-range: ^0.1.2
-    picocolors: ^1.1.1
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.1.0
-  bin:
-    autoprefixer: bin/autoprefixer
-  checksum: 11770ce635a0520e457eaf2ff89056cd57094796a9f5d6d9375513388a5a016cd947333dcfd213b822fdd8a0b43ce68ae4958e79c6f077c41d87444c8cca0235
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -1320,20 +1298,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.24.4":
-  version: 4.24.4
-  resolution: "browserslist@npm:4.24.4"
-  dependencies:
-    caniuse-lite: ^1.0.30001688
-    electron-to-chromium: ^1.5.73
-    node-releases: ^2.0.19
-    update-browserslist-db: ^1.1.1
-  bin:
-    browserslist: cli.js
-  checksum: 64074bf6cf0a9ae3094d753270e3eae9cf925149db45d646f0bc67bacc2e46d7ded64a4e835b95f5fdcf0350f63a83c3755b32f80831f643a47f0886deb8a065
-  languageName: node
-  linkType: hard
-
 "cac@npm:^6.7.14":
   version: 6.7.14
   resolution: "cac@npm:6.7.14"
@@ -1365,13 +1329,6 @@ __metadata:
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
-  version: 1.0.30001703
-  resolution: "caniuse-lite@npm:1.0.30001703"
-  checksum: f3c19e357df7f5ff480a8a24a61213d1442bf3df9e2f9563a47f4c95e9c08ea7d3c8faa965bc84dcc57c569542584c965b30d552d9b35e421f352c974980de17
   languageName: node
   linkType: hard
 
@@ -1567,13 +1524,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.73":
-  version: 1.5.114
-  resolution: "electron-to-chromium@npm:1.5.114"
-  checksum: af696acf7c57007e3362a0a7e5fb4613210d55d6bc7c7cfee32f4000aaa604a75fce41d12b081cab7d9757eefb44cafa69c17b6f8ea450d5da938c0bf84b5697
-  languageName: node
-  linkType: hard
-
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -1711,13 +1661,6 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 2c4e91948b939e711e9342e692fc3c8b0a95acbc1fc9c7628db6092c4aef7c32aa643b2782111625871756084536cebc4831b3f1d5c3b6bd4e4774e21bc4bbea
-  languageName: node
-  linkType: hard
-
-"escalade@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "escalade@npm:3.2.0"
-  checksum: 47b029c83de01b0d17ad99ed766347b974b0d628e848de404018f3abee728e987da0d2d370ad4574aa3d5b5bfc368754fd085d69a30f8e75903486ec4b5b709e
   languageName: node
   linkType: hard
 
@@ -2002,13 +1945,6 @@ __metadata:
     cross-spawn: ^7.0.6
     signal-exit: ^4.0.1
   checksum: b2c1a6fc0bf0233d645d9fefdfa999abf37db1b33e5dab172b3cbfb0662b88bfbd2c9e7ab853533d199050ec6b65c03fcf078fc212d26e4990220e98c6930eef
-  languageName: node
-  linkType: hard
-
-"fraction.js@npm:^4.3.7":
-  version: 4.3.7
-  resolution: "fraction.js@npm:4.3.7"
-  checksum: e1553ae3f08e3ba0e8c06e43a3ab20b319966dfb7ddb96fd9b5d0ee11a66571af7f993229c88ebbb0d4a816eb813a24ed48207b140d442a8f76f33763b8d1f3f
   languageName: node
   linkType: hard
 
@@ -2855,13 +2791,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.19":
-  version: 2.0.19
-  resolution: "node-releases@npm:2.0.19"
-  checksum: 917dbced519f48c6289a44830a0ca6dc944c3ee9243c468ebd8515a41c97c8b2c256edb7f3f750416bc37952cc9608684e6483c7b6c6f39f6bd8d86c52cfe658
-  languageName: node
-  linkType: hard
-
 "nopt@npm:^6.0.0":
   version: 6.0.0
   resolution: "nopt@npm:6.0.0"
@@ -2870,13 +2799,6 @@ __metadata:
   bin:
     nopt: bin/nopt.js
   checksum: 82149371f8be0c4b9ec2f863cc6509a7fd0fa729929c009f3a58e4eb0c9e4cae9920e8f1f8eb46e7d032fec8fb01bede7f0f41a67eb3553b7b8e14fa53de1dac
-  languageName: node
-  linkType: hard
-
-"normalize-range@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "normalize-range@npm:0.1.2"
-  checksum: 9b2f14f093593f367a7a0834267c24f3cb3e887a2d9809c77d8a7e5fd08738bcd15af46f0ab01cc3a3d660386f015816b5c922cea8bf2ee79777f40874063184
   languageName: node
   linkType: hard
 
@@ -3031,13 +2953,6 @@ __metadata:
   version: 4.0.2
   resolution: "picomatch@npm:4.0.2"
   checksum: a7a5188c954f82c6585720e9143297ccd0e35ad8072231608086ca950bee672d51b0ef676254af0788205e59bd4e4deb4e7708769226bed725bf13370a7d1464
-  languageName: node
-  linkType: hard
-
-"postcss-value-parser@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "postcss-value-parser@npm:4.2.0"
-  checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
   languageName: node
   linkType: hard
 
@@ -3585,20 +3500,6 @@ __metadata:
   dependencies:
     imurmurhash: ^0.1.4
   checksum: 0884b58365af59f89739e6f71e3feacb5b1b41f2df2d842d0757933620e6de08eff347d27e9d499b43c40476cbaf7988638d3acb2ffbcb9d35fd035591adfd15
-  languageName: node
-  linkType: hard
-
-"update-browserslist-db@npm:^1.1.1":
-  version: 1.1.3
-  resolution: "update-browserslist-db@npm:1.1.3"
-  dependencies:
-    escalade: ^3.2.0
-    picocolors: ^1.1.1
-  peerDependencies:
-    browserslist: ">= 4.21.0"
-  bin:
-    update-browserslist-db: cli.js
-  checksum: 7b6d8d08c34af25ee435bccac542bedcb9e57c710f3c42421615631a80aa6dd28b0a81c9d2afbef53799d482fb41453f714b8a7a0a8003e3b4ec8fb1abb819af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/7291**~~

Remove support for building CSS with autoprefixer and Tailwind v3, now that downstream projects have been migrated to use Tailwind v4 and stop using autoprefixer.