### PR TITLE
Do not duplicate sourcemap URLs when building non-sass styles

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -70,18 +70,21 @@ export async function buildCSS(inputs, { tailwind = false } = {}) {
           prev: sourceMap ? JSON.stringify(sourceMap) : undefined,
         },
       });
-      const sourceMappingURL = relative(dirname(output), sourceMapPath);
 
-      await writeFile(
-        output,
-        // We have to manually add the sourceMappingURL comment, because
-        // `sass.compile(...)` does not do it by itself.
-        // https://sass-lang.com/documentation/js-api/interfaces/Options#sourceMap
-        // It's important to know that URI-encoding the sourceMappingURL might
-        // be needed if we start using characters outside the [0-9a-zA-Z-_.] set
-        // in file names
-        `${postcssResult.css}\n/*# sourceMappingURL=${sourceMappingURL} */`,
-      );
+      const sourceMappingURL =
+        sourceMap && relative(dirname(output), sourceMapPath);
+
+      // We have to manually add the sourceMappingURL comment, because
+      // `sass.compile(...)` does not do it by itself.
+      // https://sass-lang.com/documentation/js-api/interfaces/Options#sourceMap
+      // It's important to know that URI-encoding the sourceMappingURL might
+      // be needed if we start using characters outside the [0-9a-zA-Z-_.] set
+      // in file names
+      const content = sourceMappingURL
+        ? `${postcssResult.css}\n/*# sourceMappingURL=${sourceMappingURL} */`
+        : postcssResult.css;
+
+      await writeFile(output, content);
       await writeFile(sourceMapPath, postcssResult.map.toString());
     }),
   );


### PR DESCRIPTION
While debugging a CSS source map related warning in the client, I noticed all generated CSS files had a duplicated `sourceMappingURL` instruction.

<img width="397" height="84" alt="image" src="https://github.com/user-attachments/assets/ae5fb00c-1e3b-4ca4-bc06-669189db9a9f" />

This PR ensures we only add that manually when building sass files, as the instruction gets automatically added otherwise.